### PR TITLE
fix fpermissive error with iconv

### DIFF
--- a/src/intern/drw_textcodec.cpp
+++ b/src/intern/drw_textcodec.cpp
@@ -476,7 +476,7 @@ std::string DRW_ExtConverter::convertByiconv(const char *in_encode,
     const int BUF_SIZE = 1000;
     static char in_buf[BUF_SIZE], out_buf[BUF_SIZE];
 
-	const char *in_ptr = in_buf;
+	char *in_ptr = in_buf;
 	char *out_ptr = out_buf;
     strncpy(in_buf, s->c_str(), BUF_SIZE);
 


### PR DESCRIPTION
Code fails to compile using `gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)`
```
...
intern/drw_textcodec.cpp: In member function ‘std::string DRW_ExtConverter::convertByiconv(const char*, const char*, const string*)’:
intern/drw_textcodec.cpp:486:16: error: invalid conversion from ‘const char**’ to ‘char**’ [-fpermissive]
  486 |     iconv(ic , &in_ptr, &il, &out_ptr, &ol);
      |                ^~~~~~~
      |                |
      |                const char**
In file included from intern/drw_textcodec.cpp:6:
/usr/include/iconv.h:42:54: note:   initializing argument 2 of ‘size_t iconv(iconv_t, char**, size_t*, char**, size_t*)’
   42 | extern size_t iconv (iconv_t __cd, char **__restrict __inbuf,
      |                                    ~~~~~~~~~~~~~~~~~~^~~~~~~
make[1]: *** [Makefile:534: intern/drw_textcodec.lo] Error 1

```