### PR TITLE
Fixed invalid conversion in intern/drw_textcodec.cpp:487:16

### DIFF
--- a/src/intern/drw_textcodec.cpp
+++ b/src/intern/drw_textcodec.cpp
@@ -484,7 +484,7 @@ std::string DRW_ExtConverter::convertByiconv(const char *in_encode,
     iconv_t ic;
     ic = iconv_open(out_encode, in_encode);
     size_t il = BUF_SIZE-1, ol = BUF_SIZE-1;
-    iconv(ic , (const char**)&in_ptr, &il, &out_ptr, &ol);
+    iconv(ic , (char**)&in_ptr, &il, &out_ptr, &ol);
     iconv_close(ic);
 
     return std::string(out_buf);


### PR DESCRIPTION
When trying to build the library i got this error and this fix made it compile. I don't know it it causes any other issues.
`
intern/drw_textcodec.cpp:487:16: error: invalid conversion from ‘const char**’ to ‘char**’`

> Making all in src
make[1]: Entering directory '/home/taifun/GitRepos/libdxfrw/src'
depbase=`echo intern/drw_textcodec.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
/bin/bash ../libtool  --tag=CXX   --mode=compile g++ -DPACKAGE_NAME=\"libdxfrw\" -DPACKAGE_TARNAME=\"libdxfrw\" -DPACKAGE_VERSION=\"0.6.3\" -DPACKAGE_STRING=\"libdxfrw\ 0.6.3\" -DPACKAGE_BUGREPORT=\"https://sourceforge.net/projects/libdxfrw/\" -DPACKAGE_URL=\"\" -DPACKAGE=\"libdxfrw\" -DVERSION=\"0.6.3\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE__BOOL=1 -DHAVE_STDBOOL_H=1 -I.   -Wall -Woverloaded-virtual   -g -O2 -MT intern/drw_textcodec.lo -MD -MP -MF $depbase.Tpo -c -o intern/drw_textcodec.lo intern/drw_textcodec.cpp &&\
mv -f $depbase.Tpo $depbase.Plo
libtool: compile:  g++ -DPACKAGE_NAME=\"libdxfrw\" -DPACKAGE_TARNAME=\"libdxfrw\" -DPACKAGE_VERSION=\"0.6.3\" "-DPACKAGE_STRING=\"libdxfrw 0.6.3\"" -DPACKAGE_BUGREPORT=\"https://sourceforge.net/projects/libdxfrw/\" -DPACKAGE_URL=\"\" -DPACKAGE=\"libdxfrw\" -DVERSION=\"0.6.3\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE__BOOL=1 -DHAVE_STDBOOL_H=1 -I. -Wall -Woverloaded-virtual -g -O2 -MT intern/drw_textcodec.lo -MD -MP -MF intern/.deps/drw_textcodec.Tpo -c intern/drw_textcodec.cpp  -fPIC -DPIC -o intern/.libs/drw_textcodec.o
In file included from intern/drw_textcodec.cpp:7:
intern/../drw_base.h:13: warning: ignoring #pragma warning  [-Wunknown-pragmas]
   13 | #pragma warning(disable:4996) //Ignore C4996, unsafe strncpy. TODO use safe alternative
      | 
intern/drw_textcodec.cpp: In member function ‘std::string DRW_ExtConverter::convertByiconv(const char*, const char*, const string*)’:
intern/drw_textcodec.cpp:487:16: error: invalid conversion from ‘const char**’ to ‘char**’ [-fpermissive]
  487 |     iconv(ic , (const char**)&in_ptr, &il, &out_ptr, &ol);
      |                ^~~~~~~~~~~~~~~~~~~~~
      |                |
      |                const char**
In file included from intern/drw_textcodec.cpp:6:
/usr/include/iconv.h:42:54: note:   initializing argument 2 of ‘size_t iconv(iconv_t, char**, size_t*, char**, size_t*)’
   42 | extern size_t iconv (iconv_t __cd, char **__restrict __inbuf,
      |                                    ~~~~~~~~~~~~~~~~~~^~~~~~~
make[1]: *** [Makefile:537: intern/drw_textcodec.lo] Error 1
make[1]: Leaving directory '/home/taifun/GitRepos/libdxfrw/src'
make: *** [Makefile:388: all-recursive] Error 1
