### PR TITLE
Fix integer overflow in RS decode chunk count for AC1021+ DWG files

### DIFF
--- a/src/intern/dwgreader21.cpp
+++ b/src/intern/dwgreader21.cpp
@@ -93,7 +93,7 @@ bool dwgReader21::parseDataPage(dwgSectionInfo si, duint8 *dData){
     #endif
 
         duint8 *tmpPageRS = new duint8[pi.size];
-        duint8 chunks =pi.size / 255;
+        duint32 chunks = pi.size / 255;
         dwgRSCodec::decode251I(tmpPageRaw, tmpPageRS, chunks);
     #ifdef DRW_DBG_DUMP
         DRW_DBG("\nSection OBJECTS RS data=\n");


### PR DESCRIPTION
duint8 overflows when page size exceeds 65025 bytes (255*255), causing incorrect Reed-Solomon decoding and read failure.
