### PR TITLE
dwg2dxf: Fix silent loss of entities when no output version is specified

### DIFF
--- a/dwg2dxf/dx_iface.cpp
+++ b/dwg2dxf/dx_iface.cpp
@@ -67,6 +67,12 @@ void dx_iface::writeEntity(DRW_Entity* e){
     case DRW::SOLID:
         dxfW->writeSolid(static_cast<DRW_Solid*>(e));
         break;
+    case DRW::TRACE:
+        dxfW->writeTrace(static_cast<DRW_Trace*>(e));
+        break;
+    case DRW::E3DFACE:
+        dxfW->write3dface(static_cast<DRW_3Dface*>(e));
+        break;
     case DRW::ELLIPSE:
         dxfW->writeEllipse(static_cast<DRW_Ellipse*>(e));
         break;

--- a/dwg2dxf/main.cpp
+++ b/dwg2dxf/main.cpp
@@ -92,6 +92,25 @@ bool convertFile(std::string inName, std::string outName, DRW::Version ver, bool
         return false;
     }
 
+    // If no version specified, use the source file's version
+    if (ver == DRW::UNKNOWNV) {
+        auto it = fData.headerC.vars.find("$ACADVER");
+        if (it != fData.headerC.vars.end()) {
+            std::string acadVer = *(it->second->content.s);
+            if (acadVer == "AC1006") ver = DRW::AC1006;
+            else if (acadVer == "AC1009") ver = DRW::AC1009;
+            else if (acadVer == "AC1012") ver = DRW::AC1012;
+            else if (acadVer == "AC1014") ver = DRW::AC1014;
+            else if (acadVer == "AC1015") ver = DRW::AC1015;
+            else if (acadVer == "AC1018") ver = DRW::AC1018;
+            else if (acadVer == "AC1021") ver = DRW::AC1021;
+            else if (acadVer == "AC1024") ver = DRW::AC1024;
+            else if (acadVer == "AC1027") ver = DRW::AC1027;
+            else if (acadVer == "AC1032") ver = DRW::AC1032;
+        }
+        if (ver == DRW::UNKNOWNV) ver = DRW::AC1021; // fallback
+    }
+
     //And write a dxf file
     dx_iface *output = new dx_iface();
     badState = output->fileExport(outName, ver, binary, &fData);


### PR DESCRIPTION
When no -version flag is given, the write version defaults to UNKNOWNV (value 0). Since writeLWPolyline, writeEllipse, writeHatch, writeMText and other functions check `if (version > DRW::AC1009)`, all these entities are silently dropped from the output DXF.

Fix by reading the $ACADVER variable from the source file's header and using it as the output version. Fall back to AC1021 if unavailable.

Also add missing TRACE and 3DFACE cases to writeEntity().
