### PR TITLE
Fix static variable causing text encoding corruption across multiple file loads

### DIFF
--- a/src/intern/drw_textcodec.cpp
+++ b/src/intern/drw_textcodec.cpp
@@ -55,8 +55,7 @@ void DRW_TextCodec::setVersion(std::string *v, bool dxfFormat){
 }
 
 void DRW_TextCodec::setCodePage(std::string *c, bool dxfFormat){
-    static int min_ver = 10;
-    min_ver = std::min(min_ver, version);
+    int min_ver = version;
 
     cp = correctCodePage(*c);
     delete conv;


### PR DESCRIPTION
The static local `min_ver` in DRW_TextCodec::setCodePage() persisted across calls, causing older DWG versions (e.g. AC1015) to permanently lower the threshold. Subsequent AC1021+ files would then incorrectly use SJIS decoding instead of UTF-16, producing mojibake for Unicode text.
