### PR TITLE
Fix wrong comparison in LWPolyline width assignment

### DIFF
--- a/src/drw_entities.cpp
+++ b/src/drw_entities.cpp
@@ -1261,7 +1261,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
         for (unsigned int i = 0; i < widthsnum; i++){
             double staW = buf->getBitDouble();
             double endW = buf->getBitDouble();
-            if (vertlist.size()< i) {
+            if (vertlist.size() > i) {
                 vertlist.at(i)->stawidth = staW;
                 vertlist.at(i)->endwidth = endW;
             }


### PR DESCRIPTION
The condition `vertlist.size() < i` prevented widths from ever being assigned to vertices when parsing DWG LWPolyline entities. The correct check is `vertlist.size() > i` to ensure the index is within bounds before accessing the element.