### PR TITLE
Fix second getInt32() reading wrong data for hatch loop type check

### DIFF
--- a/src/drw_entities.cpp
+++ b/src/drw_entities.cpp
@@ -1791,7 +1791,7 @@ void DRW_Hatch::parseCode(int code, dxfReader *reader){
     case 92:
         loop = new DRW_HatchLoop(reader->getInt32());
         looplist.push_back(loop);
-        if (reader->getInt32() & 2) {
+        if (loop->type & 2) {
             ispol = true;
             clearEntities();
             pline = new DRW_LWPolyline;


### PR DESCRIPTION
The loop type was already read and stored in `loop->type` via the `DRW_HatchLoop` constructor. The subsequent check called `getInt32()` again, consuming the next unrelated value from the file. Use `loop->type` instead.