### PR TITLE
Fix memory leak in dwgBuffer::operator=

### DIFF
--- a/src/intern/dwgbuffer.cpp
+++ b/src/intern/dwgbuffer.cpp
@@ -167,11 +167,14 @@ dwgBuffer::dwgBuffer( const dwgBuffer& org ){
 }
 
 dwgBuffer& dwgBuffer::operator=( const dwgBuffer& org ){
-    filestr = org.filestr->clone();
-    decoder = org.decoder;
-    maxSize = filestr->size();
-    currByte = org.currByte;
-    bitPos = org.bitPos;
+    if (this != &org) {
+        delete filestr;
+        filestr = org.filestr->clone();
+        decoder = org.decoder;
+        maxSize = filestr->size();
+        currByte = org.currByte;
+        bitPos = org.bitPos;
+    }
     return *this;
 }
 


### PR DESCRIPTION
The old `filestr` was not deleted before being overwritten with the cloned stream, leaking the previous allocation. Add a self-assignment check and delete the old `filestr` before cloning.